### PR TITLE
Huge rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,27 @@ default behaviour on Mac OS. It needs the 'Access your data for all websites'
 permission in order to access the browser's local storage and be able to save
 its settings persistently.
 
-You can configure how the browser reacts to your gestures with two settings:
+You can configure how the browser reacts to your gestures with three settings:
 
-- **Sensitivity**: this indicates how sensitle your browser is to
-horizontal swipes. If you set this value too low, you have to swipe more to 
-trigger a jump in history. If you set this value too high, you might jump back
-and forward unintentionally, or jump for more than one page. A suggested value
-is from 15 to 20.
-- **timeout**: your swipe should happen within a specific time range
-in order to trigger a history jump. This value represents that time range. If 
-you swipe too slow the jump won't be triggered. If you set this value too low, 
-you will have a hard time jumping. A suggested value is 1000 milliseconds.
+- **Sensitivity**: This indicates how sensitive your browser is to horizontal
+swipes. If you set this value too low, you have to swipe more to  trigger a jump
+in history. If you set this value too high, you might jump back and forward
+unintentionally. 30 is the default and suggested values range from 10 to 50.
+- **Timeout**: The amount of time that the browser will wait before jumping back
+or forward. If you set this value too low, it will be more difficult to cancel
+accidental jumps. If you set this value too high, you might have to wait a long
+time before you can jump back or forward. 250 is the default and suggested value.
+- **Deadzone**: The amount of pixels that will be ignored when swiping. If you
+set this value too low you are more likely to trigger the animation by accident
+when scrolling.
 
 ## Components
 
 The code is organized in three parts:
 
-- **a popup** which is used both as a standard browser action popup, and as a
+- **A popup** which is used both as a standard browser action popup, and as a
   settings page
-- **a background script** which is responsible for managing the settings and
-  store them locally
-- **a content script** which is injected in all pages and listens to scroll
+- **A background script** which is responsible for managing the settings and
+  storing them locally
+- **A content script** which is injected in all pages and listens to scroll
   events in order to trigger a history jump

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ time before you can jump back or forward. 250 is the default and suggested value
 set this value too low you are more likely to trigger the animation by accident
 when scrolling.
 
+## Demo
+
+https://user-images.githubusercontent.com/13787163/147829836-77598b5d-54de-413e-8bb8-f49f492de807.mp4
+
 ## Components
 
 The code is organized in three parts:

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This add-on allows you to jump back/forward in the browser's history by swiping
 horizontally with two fingers on your touchpad. Swiping to the left will take you
 back one page, while swiping to the right will do the opposite. It mimics the
-default behaviour on Mac Os. It needs the 'Access your data for all websites'
+default behaviour on Mac OS. It needs the 'Access your data for all websites'
 permission in order to access the browser's local storage and be able to save
 its settings persistently.
 
 You can configure how the browser reacts to your gestures with two settings:
 
-- **sensibility**: this indicates how sensible your browser is to
+- **Sensitivity**: this indicates how sensitle your browser is to
 horizontal swipes. If you set this value too low, you have to swipe more to 
 trigger a jump in history. If you set this value too high, you might jump back
 and forward unintentionally, or jump for more than one page. A suggested value

--- a/bg.js
+++ b/bg.js
@@ -5,7 +5,7 @@
 (async () => {
   // defaults
   const defaultSettings = {
-    threshold: 30,
+    threshold: 20,
     newTimeout: 250,
     deadzone: 20
   }

--- a/bg.js
+++ b/bg.js
@@ -5,7 +5,7 @@
 (async () => {
   // defaults
   const defaultSettings = {
-    threshold: 20,
+    threshold: 30,
     newTimeout: 250,
     deadzone: 20
   }

--- a/bg.js
+++ b/bg.js
@@ -6,15 +6,23 @@
   // defaults
   const defaultSettings = {
     threshold: 20,
-    timeout: 1000,
-    feedbackSize: 5,
-    feedbackColor: '#888888'
+    newTimeout: 250,
+    deadzone: 20
   }
 
   // get stored settings or default ones
   let settings = await browser.storage.local.get();
-  if (!settings || !settings.timeout || !settings.threshold) {
+  if (!settings) {
     settings = defaultSettings;
+  }
+  if (!settings.threshold) {
+    settings.threshold = defaultSettings.threshold;
+  }
+  if (!settings.newTimeout) {
+    settings.newTimeout = defaultSettings.newTimeout;
+  }
+  if (!settings.deadzone) {
+    settings.deadzone = defaultSettings.deadzone;
   }
 
   // listen to messages from content script / popup

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@
     // If the viewport was moved, ignore the scroll
     if (!viewportMoved && scrollAmountThisFrame != 0) {
       holding = true;
-      animationSlideAmount += scrollAmountThisFrame * settings.threshold * 0.005;
+      animationSlideAmount += scrollAmountThisFrame * settings.threshold * 0.0075;
       console.log(animationSlideAmount);
       lastMoveTime = currentTime;
       // Update the animation

--- a/index.js
+++ b/index.js
@@ -22,39 +22,42 @@
 
   // Add styles to the document
   let style = document.createElement('STYLE');
+  // all: initial; makes sure that the page's styling doesn't mess with our styles
   style.innerHTML = `
   #history-jump-container {
-    position: fixed;
-    top: calc(50vh - 20px);
-    display: none;
+    all: initial !important;
+    position: fixed !important;
+    top: calc(50vh - 20px) !important;
+    display: none !important;
   }
   
   .history-jump-circle {
-    height: 40px;
-    width: 40px;
-    border-radius: 20px;
-    position: absolute;
-    top: 0;
+    all: initial !important;
+    height: 40px !important;
+    width: 40px !important;
+    border-radius: 20px !important;
+    position: absolute !important;
+    top: 0 !important;
   }
   
   #history-jump-arrow {
-    background: white;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-    font-size: 24px;
-    padding: 2px 10px;
-    box-sizing: border-box;
-    color: #46f;
-    font-weight: bold;
+    background: white !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5) !important;
+    font-size: 24px !important;
+    padding: 2px 10px !important;
+    box-sizing: border-box !important;
+    color: #46f !important;
+    font-weight: bold !important;
   }
   
   #history-jump-arrow.highlighted {
-    background: #46f;
-    color: white;
+    background: #46f !important;
+    color: white !important;
   }
   
   #history-jump-indicator {
-    background: #46f;
-    opacity: 0.5;
+    background: #46f !important;
+    opacity: 0.5 !important;
   }`
   document.head.appendChild(style);
 
@@ -102,17 +105,17 @@
     }
     if (value == 0) {
       // Hide the arrow if the value is 0
-      container.style.display = "none";
+      container.style.setProperty("display", "none", "important");
     } else {
-      container.style.display = "block";
+      container.style.setProperty("display", "block", "important");
       // Put the arroe on the left or right side
       if (left) {
-        container.style.right = "";
-        container.style.left = value - 40 + "px";
+        container.style.setProperty("right", "");
+        container.style.setProperty("left", value - 40 + "px", "important");
         arrow.innerHTML = "🡠";
       } else {
-        container.style.right = value - 40 + "px";
-        container.style.left = "";
+        container.style.setProperty("right", value - 40 + "px", "important");
+        container.style.setProperty("left", "");
         arrow.innerHTML = "🡢";
       }
       // Highlight the arrow if the value is above the threshold
@@ -124,7 +127,7 @@
         highlighted = false;
       }
       // Scale the indicator circle
-      indicator.style.transform = "scale(" + (Math.min(value / 100, 1) + 1) + ")";
+      indicator.style.setProperty("transform", "scale(" + (Math.min(value / 100, 1) + 1) + ")", "important");
     }
   }
   

--- a/index.js
+++ b/index.js
@@ -143,20 +143,20 @@
   // The last time the user scrolled
   let lastMoveTime = 0;
   
-  window.visualViewport.onscroll = () => {
+  visualViewport.addEventListener("scroll", () => {
     // If the user starts scrolling the content, allow the arrow to leave the screen
     holding = false;
     // Mark that the viewport was moved - this means that scrolling is should be ignored,
     // because the user is trying to scroll the page rather than using a gesture
     viewportMoved = true;
-  }
+  })
   
-  window.onwheel = function (e) {
+  window.addEventListener("wheel", (e) => {
     // Ignore zooming and vertical scrolling
     if (!e.ctrlKey && e.deltaY == 0) {
       scrollAmountThisFrame += e.deltaX;
     }
-  }
+  })
   
   // The progress of the animation
   // Positive = navigating forward

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 // This script is responsible for implementing the functionality of
 // going back/forward in the navigation history when the user scrolls
 // the page left/right using the touchpad.
-// Each horizontal scroll event is intercepted and if the total motion
-// within a given time is greather than a threshold, the code triggers
-// a history.back() or .forward()
 // Settings are handled by the background script bg.js.
 
 (async () => {
@@ -15,58 +12,193 @@
 
   // get settings  
   let settings = await browser.runtime.sendMessage({ cmd: 'getSettings' });
-  
-  // create a visual feedback element to show the accumulator status
-  let feedback = document.createElement('DIV');
-  feedback.style.position = 'fixed';
-  feedback.style.bottom = '0';
-  feedback.style.left = '0';
-  feedback.style.opacity = '0';
-  feedback.style.width = '100%';
-  feedback.style.height = `${settings.feedbackSize || 5}px`;
-  feedback.style.backgroundColor = settings.feedbackColor || '#888888';
-  feedback.style.transition = 'left 0.1s linear, opacity 0.5s';
-  feedback.style.zIndex = 2147483647;
-  feedback.innerHTML = '&nbsp;';
-  document.body.appendChild(feedback);
 
-  // execute each time a page is scrolled
-  document.addEventListener('wheel', async e => {
-    // do nothing if scroll event is vertical
-    if (!e.deltaX) return;
-
-    // set the opacity to 100%
-    feedback.style.opacity = 1;
-    
-    // get settings again (this code doesn't seem to hurt performances and
-    // it allows to apply the latest settings without needing to reload the
-    // current page)
+  setInterval(async () => {
+    // Get settings again (this code doesn't seem to hurt performance and
+    // it allow to applying the latest settings without needing to reload
+    // the current page)
     settings = await browser.runtime.sendMessage({ cmd: 'getSettings' });
+  }, 1000);
+
+  // Add styles to the document
+  let style = document.createElement('STYLE');
+  style.innerHTML = `
+  #history-jump-container {
+    position: fixed;
+    top: calc(50vh - 20px);
+    display: none;
+  }
   
-    // cancel the reset timeout
-    clearTimeout(timeout);
+  .history-jump-circle {
+    height: 40px;
+    width: 40px;
+    border-radius: 20px;
+    position: absolute;
+    top: 0;
+  }
+  
+  #history-jump-arrow {
+    background: white;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+    font-size: 24px;
+    padding: 2px 10px;
+    box-sizing: border-box;
+    color: #46f;
+    font-weight: bold;
+  }
+  
+  #history-jump-arrow.highlighted {
+    background: #46f;
+    color: white;
+  }
+  
+  #history-jump-indicator {
+    background: #46f;
+    opacity: 0.5;
+  }`
+  document.head.appendChild(style);
 
-    // accumulates the motion from this event
-    counter += e.deltaX;
+  // Arrow similar to the one in Google Chrome
 
-    // move the feedback div to show the accumulator status
-    feedback.style.left = Math.floor((counter / (50 - settings.threshold)) * 100) + '%';
+  // Container to hold everything
+  let container = document.createElement('DIV');
+  container.id = 'history-jump-container';
 
-    // if the total motion is greather than threshold
-    if (Math.abs(counter) >= (50 - settings.threshold)) {
-      // move the feedback div out of the way
-      feedback.style.display = 'none';
-      setTimeout(() => feedback.style.display = 'initial', settings.timeout + 400);
+  // Blue translucent circle that changes size
+  let indicator = document.createElement('DIV');
+  indicator.className = 'history-jump-circle';
+  indicator.id = 'history-jump-indicator';
 
-      // navigate back/forward in history
-      if (counter > 0) { 
-        setTimeout(window.history.forward(), 200);
-      } else {
-        setTimeout(window.history.back(), 200);
-      }
+  // Circle with the arrow
+  let arrow = document.createElement('DIV');
+  arrow.className = 'history-jump-circle';
+  arrow.id = 'history-jump-arrow';
+  arrow.innerHTML = '🡠';
+
+  // Append everything to the document
+  container.appendChild(indicator);
+  container.appendChild(arrow);
+  document.body.appendChild(container);
+
+  // Whether the arrow is highlighted or not
+  let highlighted = false;
+
+  // Updates the animation
+  function setValue(value) {
+    // Whether the arrow is on the left or right side
+    let left = value < 0;
+    // Make sure the value is always positive
+    if (left) {
+      value *= -1;
     }
-    
-    // in any case, reset the motion accumulator and the feedback after a timeout
-    timeout = setTimeout(() => feedback.style.opacity = feedback.style.left = counter = 0, settings.timeout);
-  });
+    // Make the first 20 pixels of scroll do nothing
+    value = Math.max(0, value - settings.deadzone);
+    // Make the animation level off after 100 pixels (a bit messy/difficult to understand)
+    // Honestly I just messed around in a graph plotter until it looked right, so I don't fully understand it
+    if (value > 100) {
+      value -= 100;
+      value = ((value / 50) / ((value / 50) + 1) * 50);
+      value += 100;
+    }
+    if (value == 0) {
+      // Hide the arrow if the value is 0
+      container.style.display = "none";
+    } else {
+      container.style.display = "block";
+      // Put the arroe on the left or right side
+      if (left) {
+        container.style.right = "";
+        container.style.left = value - 40 + "px";
+        arrow.innerHTML = "🡠";
+      } else {
+        container.style.right = value - 40 + "px";
+        container.style.left = "";
+        arrow.innerHTML = "🡢";
+      }
+      // Highlight the arrow if the value is above the threshold
+      if (value > 100) {
+        arrow.classList.add("highlighted");
+        highlighted = true;
+      } else {
+        arrow.classList.remove("highlighted");
+        highlighted = false;
+      }
+      // Scale the indicator circle
+      indicator.style.transform = "scale(" + (Math.min(value / 100, 1) + 1) + ")";
+    }
+  }
+  
+  let viewportMoved = false;
+  // The amount of horizontal scroll in the current frame
+  let scrollAmountThisFrame = 0;
+  
+  let holding = false;
+  
+  // The last time the user scrolled
+  let lastMoveTime = 0;
+  
+  window.visualViewport.onscroll = () => {
+    // If the user starts scrolling the content, allow the arrow to leave the screen
+    holding = false;
+    // Mark that the viewport was moved - this means that scrolling is should be ignored,
+    // because the user is trying to scroll the page rather than using a gesture
+    viewportMoved = true;
+  }
+  
+  window.onwheel = function (e) {
+    // Ignore zooming and vertical scrolling
+    if (!e.ctrlKey && e.deltaY == 0) {
+      scrollAmountThisFrame += e.deltaX;
+    }
+  }
+  
+  // The progress of the animation
+  // Positive = navigating forward
+  // Negative = navigating backward
+  let animationSlideAmount = 0;
+  
+  // Called every frame
+  // TODO: Make sure it works with high refresh rates
+  function step() {
+    let currentTime = +new Date();
+    // If the viewport was moved, ignore the scroll
+    if (!viewportMoved && scrollAmountThisFrame != 0) {
+      holding = true;
+      animationSlideAmount += scrollAmountThisFrame * settings.threshold * 0.005;
+      console.log(animationSlideAmount);
+      lastMoveTime = currentTime;
+      // Update the animation
+      setValue(animationSlideAmount);
+    } else if (!holding && animationSlideAmount != 0) {
+      if (Math.abs(animationSlideAmount) < 20) {
+        animationSlideAmount = 0;
+      } else {
+        animationSlideAmount += animationSlideAmount > 0 ? -20 : 20;
+      }
+      // Update the animation
+      setValue(animationSlideAmount);
+    }
+    // When the animation times out, it will be reset if the arrow is not highlighted
+    // If the arrow is highlighted, the action will be performed
+    let timedOut = (currentTime - lastMoveTime) > settings.newTimeout;
+    if (timedOut) {
+      holding = false;
+    }
+    if (highlighted && timedOut) {
+      highlighted = false;
+      if (animationSlideAmount > 0) {
+        history.forward();
+      } else {
+        history.back();
+      }
+      animationSlideAmount = 0;
+      // Update the animation
+      setValue(animationSlideAmount);
+    }
+    viewportMoved = false;
+    scrollAmountThisFrame = 0;
+    window.requestAnimationFrame(step);
+  }
+  
+  window.requestAnimationFrame(step);
 })();

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@
     position: fixed !important;
     top: calc(50vh - 20px) !important;
     display: none !important;
+    z-index: 2147483647 !important;
   }
   
   .history-jump-circle {
@@ -111,11 +112,13 @@
       // Put the arroe on the left or right side
       if (left) {
         container.style.setProperty("right", "");
-        container.style.setProperty("left", value - 40 + "px", "important");
+        container.style.setProperty("left", "-40px", "important");
+        container.style.setProperty("transform", "translatex(" + value + "px)", "important");
         arrow.innerHTML = "🡠";
       } else {
-        container.style.setProperty("right", value - 40 + "px", "important");
+        container.style.setProperty("right", "-40px", "important");
         container.style.setProperty("left", "");
+        container.style.setProperty("transform", "translatex(-" + value + "px)", "important");
         arrow.innerHTML = "🡢";
       }
       // Highlight the arrow if the value is above the threshold
@@ -168,7 +171,6 @@
     if (!viewportMoved && scrollAmountThisFrame != 0) {
       holding = true;
       animationSlideAmount += scrollAmountThisFrame * settings.threshold * 0.0075;
-      console.log(animationSlideAmount);
       lastMoveTime = currentTime;
       // Update the animation
       setValue(animationSlideAmount);

--- a/index.js
+++ b/index.js
@@ -140,7 +140,9 @@
   
   let holding = false;
   
-  // The last time the user scrolled
+  // The last time the user scrolled (does not include overscroll)
+  let lastScrollTime = 0;
+  // The last time the user moved the arrow by scrolling
   let lastMoveTime = 0;
   
   function scrolled () {
@@ -149,12 +151,20 @@
     // Mark that the user scrolled - this means that touchpad scrolling should be
     // ignored, because the user is trying to scroll the page rather than using a gesture
     userScrolled = true;
+    lastScrollTime = Date.now();
   }
   
   visualViewport.addEventListener("scroll", scrolled);
   document.addEventListener("scroll", scrolled, true);
   
   window.addEventListener("wheel", (e) => {
+    const currentTime = Date.now();
+    if (currentTime - lastScrollTime < settings.newTimeout) {
+      // Count this as a scroll if the user scrolled recently
+      lastScrollTime = currentTime;
+      return;
+    }
+
     // Ignore zooming and vertical scrolling
     if (!e.ctrlKey && e.deltaY == 0) {
       scrollAmountThisFrame += e.deltaX;
@@ -169,7 +179,7 @@
   // Called every frame
   // TODO: Make sure it works with high refresh rates
   function step() {
-    let currentTime = +new Date();
+    let currentTime = Date.now();
     // If the viewport was moved, ignore the scroll
     if (!userScrolled && scrollAmountThisFrame != 0) {
       holding = true;

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@
     }
   }
   
-  let viewportMoved = false;
+  let userScrolled = false;
   // The amount of horizontal scroll in the current frame
   let scrollAmountThisFrame = 0;
   
@@ -143,13 +143,16 @@
   // The last time the user scrolled
   let lastMoveTime = 0;
   
-  visualViewport.addEventListener("scroll", () => {
+  function scrolled () {
     // If the user starts scrolling the content, allow the arrow to leave the screen
     holding = false;
-    // Mark that the viewport was moved - this means that scrolling is should be ignored,
-    // because the user is trying to scroll the page rather than using a gesture
-    viewportMoved = true;
-  })
+    // Mark that the user scrolled - this means that touchpad scrolling should be
+    // ignored, because the user is trying to scroll the page rather than using a gesture
+    userScrolled = true;
+  }
+  
+  visualViewport.addEventListener("scroll", scrolled);
+  document.addEventListener("scroll", scrolled, true);
   
   window.addEventListener("wheel", (e) => {
     // Ignore zooming and vertical scrolling
@@ -168,7 +171,7 @@
   function step() {
     let currentTime = +new Date();
     // If the viewport was moved, ignore the scroll
-    if (!viewportMoved && scrollAmountThisFrame != 0) {
+    if (!userScrolled && scrollAmountThisFrame != 0) {
       holding = true;
       animationSlideAmount += scrollAmountThisFrame * settings.threshold * 0.0075;
       lastMoveTime = currentTime;
@@ -200,7 +203,7 @@
       // Update the animation
       setValue(animationSlideAmount);
     }
-    viewportMoved = false;
+    userScrolled = false;
     scrollAmountThisFrame = 0;
     window.requestAnimationFrame(step);
   }

--- a/index.js
+++ b/index.js
@@ -113,12 +113,12 @@
       if (left) {
         container.style.setProperty("right", "");
         container.style.setProperty("left", "-40px", "important");
-        container.style.setProperty("transform", "translatex(" + value + "px)", "important");
+        container.style.setProperty("transform", "translateX(" + Math.floor(value) + "px)", "important");
         arrow.innerHTML = "🡠";
       } else {
         container.style.setProperty("right", "-40px", "important");
         container.style.setProperty("left", "");
-        container.style.setProperty("transform", "translatex(-" + value + "px)", "important");
+        container.style.setProperty("transform", "translateX(-" + Math.floor(value) + "px)", "important");
         arrow.innerHTML = "🡢";
       }
       // Highlight the arrow if the value is above the threshold

--- a/manifest.json
+++ b/manifest.json
@@ -45,12 +45,6 @@
 
   "background": {
     "scripts": ["bg.js"]
-  },
-
-  "browser_specific_settings": {
-    "gecko": {
-        "id": "two-finger-history-jump@heathmitchell27.com"
-    }
   }
 
 }

--- a/manifest.json
+++ b/manifest.json
@@ -45,6 +45,12 @@
 
   "background": {
     "scripts": ["bg.js"]
+  },
+
+  "browser_specific_settings": {
+    "gecko": {
+        "id": "two-finger-history-jump@heathmitchell27.com"
+    }
   }
 
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Two-Finger History Jump",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "This add-on allows you to jump back/forward in the browser's history by swiping horizontally with two fingers on your touchpad. It mimics the default behaviour on Mac Os. It needs the 'Access your data for all websites' permission in order to access the browser's local storage and be able to save its settings persistently.",
 
   "icons": {
@@ -45,12 +45,6 @@
 
   "background": {
     "scripts": ["bg.js"]
-  },
-
-  "browser_specific_settings": {
-    "gecko": {
-        "id": "two-finger-history-jump@heathmitchell27.com"
-    }
   }
 
 }

--- a/popup.css
+++ b/popup.css
@@ -104,7 +104,7 @@ input {
 }
 
 .info {
-  padding: 0.4rem;
+  padding: 0.4rem 1.5rem;
   background-color: var(--blue-40);
   color: var(--white-100);
 }

--- a/popup.css
+++ b/popup.css
@@ -104,13 +104,13 @@ input {
 }
 
 .info {
-  padding: 1rem;
+  padding: 0.4rem;
   background-color: var(--blue-40);
   color: var(--white-100);
 }
 
 .info .icon {
-  font-size: 1.5rem;
+  font-size: 1rem;
   float: left;
   margin: 0 0.5rem;
 }
@@ -118,7 +118,7 @@ input {
 .badge {
   background: var(--grey-70);
   color: var(--grey-20);
-  padding: 0.4rem;
+  padding: 0.2rem;
   border-radius: 1rem;
   font-size: 0.8rem;
 }

--- a/popup.html
+++ b/popup.html
@@ -20,21 +20,27 @@
           you back one page, while swiping to the right will do the opposite.
         </p>
         <p>
-          You can configure how the browser reacts to your gestures with two settings:
+          You can configure how the browser reacts to your gestures with three settings:
         </p>
         <ul>
           <li>
-            <strong>sensibility</strong>: this indicates how sensible your browser is to
+            <strong>Senitivity</strong>: This indicates how sensitive your browser is to
             horizontal swipes. If you set this value too low, you have to swipe more to 
             trigger a jump in history. If you set this value too high, you might jump back
-            and forward unintentionally, or jump for more than one page. A suggested value
-            is from 15 to 20.
+            and forward unintentionally. 10 is the default and suggested values range from
+            10 to 50.
           </li>
           <li>
-            <strong>timeout</strong>: your swipe should happen within a specific time range
-            in order to trigger a history jump. This value represents that time range. If 
-            you swipe too slow the jump won't be triggered. If you set this value too low, 
-            you will have a hard time jumping. A suggested value is 1000 milliseconds.
+            <strong>Timeout</strong>: The amount of time that the browser will wait before
+            jumping back or forward. If you set this value too low, it will be more
+            difficult to cancel accidental jumps. If you set this value too high, you might
+            have to wait a long time before you can jump back or forward. 250 is the default
+            and suggested value.
+          </li>
+          <li>
+            <strong>Deadzone</strong>: The amount of pixels that will be ignored when
+            swiping. If you set this value too low you are more likely to trigger the
+            animation by accident when scrolling.
           </li>
         </ul>
       </div>
@@ -46,21 +52,21 @@
             <span id="threshold-badge" class="badge">ERR</span>
           </div>
           <div class="panel-formElements-item">
-            <input type="range" value="-1" min="1" max="50" name="threshold" id="threshold" />
+            <input type="range" value="-1" min="5" max="100" name="threshold" id="threshold" />
           </div>
           <div class="panel-formElements-item">
-            <label for"timeout">Timeout:</label>
+            <label for="timeout">Timeout:</label>
             <span id="timeout-badge" class="badge">ERR</span>
           </div>
           <div class="panel-formElements-item">
-            <input type="range" value="-1" min="100" max="5000" name="timeout" id="timeout" />
+            <input type="range" value="-1" min="50" max="1000" name="timeout" id="timeout" />
           </div>
           <div class="panel-formElements-item">
-            <label for"feedback-size">Feedback bar size:</label>
-            <span id="feedback-size-badge" class="badge">ERR</span>
+            <label for="deadzone">Deadzone:</label>
+            <span id="deadzone-badge" class="badge">ERR</span>
           </div>
           <div class="panel-formElements-item">
-            <input type="range" value="-1" min="0" max="20" name="feedback-size" id="feedback-size" />
+            <input type="range" value="-1" min="0" max="50" name="deadzone" id="deadzone" />
           </div>
           <!--
           <div class="panel-formElements-item">

--- a/popup.html
+++ b/popup.html
@@ -48,7 +48,7 @@
       <main>
         <div class="panel-section panel-section-formElements">
           <div class="panel-formElements-item">
-            <label for="threshold">Sensibility:</label>
+            <label for="threshold">Senitivity:</label>
             <span id="threshold-badge" class="badge">ERR</span>
           </div>
           <div class="panel-formElements-item">
@@ -81,9 +81,14 @@
       </main>
 
       <footer class="panel-section panel-section-footer">
-        <button class="panel-section-footer-button" id="reset-btn">Reset</button>
+        <button class="panel-section-footer-button" id="reset-btn">
+          <!-- Not sure why there's an offset but this fixes it -->
+          <span style="position: relative; bottom: 2px;">Reset</span>
+        </button>
         <div class="panel-section-footer-separator"></div>
-        <button class="panel-section-footer-button default" id="save-btn">Save</button>
+        <button class="panel-section-footer-button default" id="save-btn">
+          <span style="position: relative; bottom: 2px;">Save</span>
+        </button>
       </footer>
     </div>
     <script src="popup.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -27,7 +27,7 @@
             <strong>Senitivity</strong>: This indicates how sensitive your browser is to
             horizontal swipes. If you set this value too low, you have to swipe more to 
             trigger a jump in history. If you set this value too high, you might jump back
-            and forward unintentionally. 30 is the default and suggested values range from
+            and forward unintentionally. 20 is the default and suggested values range from
             10 to 50.
           </li>
           <li>

--- a/popup.html
+++ b/popup.html
@@ -27,7 +27,7 @@
             <strong>Senitivity</strong>: This indicates how sensitive your browser is to
             horizontal swipes. If you set this value too low, you have to swipe more to 
             trigger a jump in history. If you set this value too high, you might jump back
-            and forward unintentionally. 20 is the default and suggested values range from
+            and forward unintentionally. 30 is the default and suggested values range from
             10 to 50.
           </li>
           <li>

--- a/popup.js
+++ b/popup.js
@@ -31,12 +31,13 @@
 
   // updates the UI given the current settings
   const updateUI = settings => {
-    document.querySelector('#timeout').value = settings.timeout;
-    document.querySelector('#timeout-badge').innerText = `${settings.timeout} ms`;
+    // Timeout is renamed because the old default is now unsuitable so it should not carry over
+    document.querySelector('#timeout').value = settings.newTimeout;
+    document.querySelector('#timeout-badge').innerText = `${settings.newTimeout} ms`;
     document.querySelector('#threshold').value = settings.threshold;
     document.querySelector('#threshold-badge').innerText = settings.threshold;
-    document.querySelector('#feedback-size').value = settings.feedbackSize;
-    document.querySelector('#feedback-size-badge').innerText = `${settings.feedbackSize} pixels`;
+    document.querySelector('#deadzone').value = settings.deadzone;
+    document.querySelector('#deadzone-badge').innerText = `${settings.deadzone} pixels`;
     // document.querySelector('#feedback-color').value = settings.feedbackColor;
     // document.querySelector('#feedback-color-badge').innerText = settings.feedbackColor;
   };
@@ -61,12 +62,12 @@
   });
 
   document.querySelector('#timeout').addEventListener('change', e => {
-    settings.timeout = parseInt(e.target.value);
+    settings.newTimeout = parseInt(e.target.value);
     handleSettingsUpdate();
   });
 
-  document.querySelector('#feedback-size').addEventListener('change', e => {
-    settings.feedbackSize = parseInt(e.target.value);
+  document.querySelector('#deadzone').addEventListener('change', e => {
+    settings.deadzone = parseInt(e.target.value);
     handleSettingsUpdate();
   });
 


### PR DESCRIPTION
This is almost a full rewrite of the code that runs on the page. Changes:
- Ignores normal horizontal scrolling and only considers overscroll, so you can still scroll normally
- Makes the feedback indicator work and look like the one in Google Chrome
- Changes how all the settings work
- Version bumped to 2.0
- Probably more

Demo:
https://user-images.githubusercontent.com/13787163/147829836-77598b5d-54de-413e-8bb8-f49f492de807.mp4

Known bugs:
- You can trigger the animation even if there is no page to go back/forward to (seems to be unfixable or very hard to fix with the current extension API)
- ~~Sites like example.com that style the div element can mess up the styling~~ Fixed by https://github.com/leonixyz/two-finger-history-jump/pull/9/commits/043df1880c58a84ae5544a982187f491694d63e0
- The page has to load before it will work, but I think that's an issue with the original too
- Zooming in on the touchpad scales/moves the animation too

Fixes:
- #4
- #6
- #7